### PR TITLE
Updated hoodwink-okta-country.py and README

### DIFF
--- a/OKTA/hoodwink-okta-country.py
+++ b/OKTA/hoodwink-okta-country.py
@@ -3,6 +3,7 @@ import csv
 # Initialize a dictionary to store the count of "SUCCESS" results per country
 success_counts = {}
 
+
 # Open the csv file and read it using the csv module
 with open('insert-your-log-filename.csv', 'r') as f:
     reader = csv.reader(f)
@@ -13,8 +14,9 @@ with open('insert-your-log-filename.csv', 'r') as f:
         # Get the value for the "outcome.result" column and the "client.geographical_context.country" column
         result = row[6]
         country = row[24]
-        # If the result is "SUCCESS", increment the count for the corresponding country
-        if result == 'SUCCESS':
+        transactionType = row[30]
+        # If the result is "SUCCESS" and transactionType is WEB, this indicates a user authentication and increments the count for the corresponding country
+        if result == 'SUCCESS' and transactionType == "WEB":
             if country in success_counts:
                 success_counts[country] += 1
             else:

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Hoodwink Okta uses Okta authentication logs to identify how many unique active u
 2. Access Reports>Application Usage
 3. Set the time range to 180+ days and click the "Request report" button
 4. Check your email for the report link and download the csv 
-5. Open hoodwink-duo.py and modify 'insert-your-log-filename.csv' to the name of the downloaded CSV file 
-6. Run hoodwink-duo.py w/ the JSON CSV in the same folder
+5. Open hoodwink-okta.py and modify 'insert-your-log-filename.csv' to the name of the downloaded CSV file 
+6. Run hoodwink-okta.py w/ the JSON CSV in the same folder
 
 **How to use hoodwink-okta-country**
 
@@ -59,8 +59,8 @@ Hoodwink Okta Country uses Okta authentication logs to identify how many success
 1. Access your Okta Admin console 
 2. Access Reports>System Log
 3. Set the time range to 180+ days and click the "Download CSV" link 
-5. Open hoodwink-duo-country.py and modify 'insert-your-log-filename.csv' to the name of the downloaded CSV file 
-6. Run hoodwink-duo-country.py w/ the CSV file in the same folder
+5. Open hoodwink-okta-country.py and modify 'insert-your-log-filename.csv' to the name of the downloaded CSV file 
+6. Run hoodwink-okta-country.py w/ the CSV file in the same folder
 
 
 **hoodwink-azure-ad**


### PR DESCRIPTION
Updated README to fix script names

Added logic to hoodwink-okta-country.py to not count logs that aren't for user authentication, as this will lead to confusing output, with a line that has a blank value for country (since non-user SUCCESS events don't have geolocation data) and the events themselves aren't relevant. 